### PR TITLE
Delete TinyGPS and RFID libraries before cloning them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,8 @@ before_install:
     # Install Travis CI configuration for Arduino sketches
     - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/install.sh)
     # Remove arduino libraries
-    - rm -rf $HOME/arduino_ide/libraries
+    - rm -rf $HOME/arduino_ide/libraries/TinyGPS
+    - rm -rf $HOME/arduino_ide/libraries/RFID-RC522
 
 install:
     # Install Smartcar shield library (used by our sketch)


### PR DESCRIPTION
## Related issue(s)
#76 